### PR TITLE
  Fix: Replace global advisory lock with per-series locking for sync …

### DIFF
--- a/packages/server/src/sync/__tests__/concurrent.ts
+++ b/packages/server/src/sync/__tests__/concurrent.ts
@@ -1,0 +1,222 @@
+import { v1 as uuidv1 } from 'uuid'
+import { pgp } from 'scdb'
+import { runSyncOnce } from '../process'
+import { ACTIVE } from '../mergeserver'
+import { seriesLockId } from '../constants'
+import { DB1, DB2, getTestDB, testids, timingpause } from './helpers'
+
+const series1 = 'conctest1'
+const series2 = 'conctest2'
+
+const ids1 = {
+    ...testids,
+    series: series1,
+    seriespassword: series1,
+    driverid1: '00000000-0000-0000-0000-000000000101',
+    carid1:    '00000000-0000-0000-0000-000000000102',
+    eventid1:  '00000000-0000-0000-0000-000000000110'
+}
+
+const ids2 = {
+    ...testids,
+    series: series2,
+    seriespassword: series2,
+    driverid1: '00000000-0000-0000-0000-000000000201',
+    carid1:    '00000000-0000-0000-0000-000000000202',
+    eventid1:  '00000000-0000-0000-0000-000000000210'
+}
+
+const LOCALID = '00000000-0000-0000-0000-000000000000'
+
+// Drops all test schemas, clears public tables, re-inserts local merge server
+const CLEAN_DB = `
+DROP SCHEMA IF EXISTS testseries CASCADE;
+DROP SCHEMA IF EXISTS ${series1} CASCADE;
+DROP SCHEMA IF EXISTS ${series2} CASCADE;
+DELETE FROM weekendmembers;
+DELETE FROM drivers;
+DELETE FROM mergeservers;
+DELETE FROM publiclog;
+INSERT INTO mergeservers(serverid, hostname, address, ctimeout) VALUES ('${LOCALID}', 'localhost', '127.0.0.1', 10);
+`
+
+function setupSeries(ids: typeof ids1) {
+    return `
+SELECT verify_user('${ids.series}', '${ids.seriespassword}');
+SELECT verify_series('${ids.series}');
+
+SET search_path='${ids.series}','public';
+
+INSERT INTO indexlist (indexcode, descrip, value) VALUES ('', '', 1.000);
+INSERT INTO classlist (classcode, descrip, indexcode, caridxrestrict, classmultiplier, carindexed, usecarflag, eventtrophy, champtrophy, secondruns, countedruns, modified)
+    VALUES ('c1', '', '', '', 1.0, 't', 'f', 't', 't', 'f', 0, now());
+
+INSERT INTO drivers (driverid, firstname, lastname, email, username, password, created)
+    VALUES ('${ids.driverid1}', 'first_${ids.series}', 'last_${ids.series}', '${ids.series}@test', '${ids.series}', '${ids.password}', '1970-01-01T00:00:00');
+INSERT INTO cars (carid, driverid, classcode, indexcode, number, useclsmult, attr, modified)
+    VALUES ('${ids.carid1}', '${ids.driverid1}', 'c1', '', 1, 'f', '{}', now());
+INSERT INTO events (eventid, name, date, regclosed, attr)
+    VALUES ('${ids.eventid1}', '${ids.series}_event', now(), now(), '{}');
+INSERT INTO runorder (eventid, course, rungroup, cars)
+    VALUES ('${ids.eventid1}', 1, 1, '{${ids.carid1}}');
+INSERT INTO runs (eventid, carid, course, rungroup, run, raw, status, attr)
+    VALUES ('${ids.eventid1}', '${ids.carid1}', 1, 1, 1, 10.0, 'OK', '{}');
+`
+}
+
+const ims = 'INSERT INTO mergeservers(serverid, hostname, address, ctimeout, hoststate) VALUES ($1, $2, $3, $4, $5)'
+
+async function resetConcurrentData() {
+    const serverids = [uuidv1(), uuidv1()]
+    const ports = [DB1, DB2]
+
+    // Clean both DBs completely first (schemas must drop before drivers due to FK)
+    for (const port of ports) {
+        await getTestDB(port).any(CLEAN_DB)
+    }
+
+    // Set up series data on DB1, empty schemas on DB2
+    const db1 = getTestDB(DB1)
+    await db1.any(setupSeries(ids1))
+    await db1.any(setupSeries(ids2))
+
+    const db2 = getTestDB(DB2)
+    await db2.any(`SELECT verify_user('${series1}', '${series1}'); SELECT verify_series('${series1}');`)
+    await db2.any(`SELECT verify_user('${series2}', '${series2}'); SELECT verify_series('${series2}');`)
+
+    // Set up merge server entries pointing at the other DB
+    for (const port of ports) {
+        const d = getTestDB(port)
+        const other = ports.find(p => p !== port)!
+        await d.none(ims, [serverids[ports.indexOf(other)], `server${other}`, `127.0.0.1:${other}`, 5, ACTIVE])
+    }
+
+    // Initial sync to get both DBs in the same state
+    await db1.none("UPDATE mergeservers SET lastcheck='epoch', nextcheck='epoch'")
+    await runSyncOnce(db1)
+}
+
+async function doSyncForSeries(port: number, series: string) {
+    const db = getTestDB(port)
+    await db.none("UPDATE mergeservers SET lastcheck='epoch', nextcheck='epoch'")
+    await runSyncOnce(db)
+    // Verify no errors for the specified series
+    for (const row of await db.many('select mergestate->$1 as state from mergeservers', [series])) {
+        if (row.state) {
+            expect(row.state.error).toBeUndefined()
+        }
+    }
+}
+
+beforeEach(async () => {
+    await resetConcurrentData()
+}, 30000)
+
+afterAll(async () => {
+    // Clean up our test schemas so other test files start fresh
+    for (const port of [DB1, DB2]) {
+        const d = getTestDB(port)
+        await d.any(`DROP SCHEMA IF EXISTS ${series1} CASCADE`)
+        await d.any(`DROP SCHEMA IF EXISTS ${series2} CASCADE`)
+    }
+    pgp.end()
+})
+
+describe('concurrent series sync', () => {
+
+    test('seriesLockId produces different IDs for different series', () => {
+        const id1 = seriesLockId(series1)
+        const id2 = seriesLockId(series2)
+        expect(id1).not.toEqual(id2)
+        expect(id1).toBeGreaterThan(0)
+        expect(id2).toBeGreaterThan(0)
+    })
+
+    test('two series with only run changes sync without global lock contention', async () => {
+        const db1 = getTestDB(DB1)
+        const db2 = getTestDB(DB2)
+
+        // Modify runs in series1 on DB1
+        await db1.none(`SET search_path='${series1}','public'`)
+        await db1.none(`UPDATE runs SET raw=11.111, modified=now() WHERE eventid='${ids1.eventid1}' AND run=1`)
+
+        await timingpause()
+
+        // Modify runs in series2 on DB2
+        await db2.none(`SET search_path='${series2}','public'`)
+        await db2.none(`UPDATE runs SET raw=22.222, modified=now() WHERE eventid='${ids2.eventid1}' AND run=1`)
+
+        // Sync from DB1 — both series should merge without issues
+        await doSyncForSeries(DB1, series1)
+
+        // Verify series1 run synced to DB2
+        await db2.none(`SET search_path='${series1}','public'`)
+        const run1 = await db2.one(`SELECT raw FROM runs WHERE eventid='${ids1.eventid1}' AND run=1`)
+        expect(parseFloat(run1.raw)).toBeCloseTo(11.111)
+
+        // Verify series2 run synced to DB1
+        await db1.none(`SET search_path='${series2}','public'`)
+        const run2 = await db1.one(`SELECT raw FROM runs WHERE eventid='${ids2.eventid1}' AND run=1`)
+        expect(parseFloat(run2.raw)).toBeCloseTo(22.222)
+    })
+
+    test('driver change in one series does not block run sync in another', async () => {
+        const db1 = getTestDB(DB1)
+        const db2 = getTestDB(DB2)
+
+        // Modify a driver (public table) via series1 on DB1
+        await db1.none(`SET search_path='${series1}','public'`)
+        await db1.none(`UPDATE drivers SET firstname='modified_driver', modified=now() WHERE driverid='${ids1.driverid1}'`)
+
+        await timingpause()
+
+        // Modify only runs in series2 on DB2 (no public table changes)
+        await db2.none(`SET search_path='${series2}','public'`)
+        await db2.none(`UPDATE runs SET raw=33.333, modified=now() WHERE eventid='${ids2.eventid1}' AND run=1`)
+
+        // Sync — series2 should only need per-series lock, series1 needs global + per-series
+        await doSyncForSeries(DB1, series1)
+
+        // Verify driver change synced
+        await db2.none(`SET search_path='${series1}','public'`)
+        const driver = await db2.one(`SELECT firstname FROM drivers WHERE driverid='${ids1.driverid1}'`)
+        expect(driver.firstname).toEqual('modified_driver')
+
+        // Verify run change synced
+        await db1.none(`SET search_path='${series2}','public'`)
+        const run = await db1.one(`SELECT raw FROM runs WHERE eventid='${ids2.eventid1}' AND run=1`)
+        expect(parseFloat(run.raw)).toBeCloseTo(33.333)
+    })
+
+    test('new driver with car and runs syncs correctly across series boundary', async () => {
+        const db1 = getTestDB(DB1)
+        const newDriverId = '00000000-0000-0000-0000-000000000301'
+        const newCarId    = '00000000-0000-0000-0000-000000000302'
+
+        // Add a new driver + car + run in series1 on DB1
+        await db1.none(`SET search_path='${series1}','public'`)
+        await db1.none(`INSERT INTO drivers (driverid, firstname, lastname, email, username, password, created)
+            VALUES ('${newDriverId}', 'new', 'driver', 'new@test', 'newuser', '${ids1.password}', '1970-01-01T00:00:00')`)
+        await db1.none(`INSERT INTO cars (carid, driverid, classcode, indexcode, number, useclsmult, attr, modified)
+            VALUES ('${newCarId}', '${newDriverId}', 'c1', '', 2, 'f', '{}', now())`)
+        await db1.none(`INSERT INTO registered (eventid, carid, session, modified) VALUES ('${ids1.eventid1}', '${newCarId}', '', now())`)
+        await db1.none(`INSERT INTO runs (eventid, carid, course, rungroup, run, raw, status, attr)
+            VALUES ('${ids1.eventid1}', '${newCarId}', 1, 1, 1, 55.555, 'OK', '{}')`)
+
+        await doSyncForSeries(DB1, series1)
+
+        // Verify new driver + car + run arrived on DB2
+        const db2 = getTestDB(DB2)
+        const driver = await db2.oneOrNone(`SELECT * FROM drivers WHERE driverid='${newDriverId}'`)
+        expect(driver).not.toBeNull()
+        expect(driver.firstname).toEqual('new')
+
+        await db2.none(`SET search_path='${series1}','public'`)
+        const car = await db2.oneOrNone(`SELECT * FROM cars WHERE carid='${newCarId}'`)
+        expect(car).not.toBeNull()
+
+        const run = await db2.oneOrNone(`SELECT * FROM runs WHERE carid='${newCarId}' AND run=1`)
+        expect(run).not.toBeNull()
+        expect(parseFloat(run.raw)).toBeCloseTo(55.555)
+    })
+})

--- a/packages/server/src/sync/constants.ts
+++ b/packages/server/src/sync/constants.ts
@@ -51,6 +51,17 @@ export async function asyncwait(ms: number) {
     return new Promise(resolve => { setTimeout(resolve, ms) })
 }
 
+export function seriesLockId(series: string): number {
+    // Generate a stable per-series advisory lock ID from the series name.
+    // This allows different series to sync concurrently without blocking each other.
+    // Uses a simple hash (djb2) mapped to a positive 32-bit integer range.
+    let hash = 5381
+    for (let i = 0; i < series.length; i++) {
+        hash = ((hash << 5) + hash + series.charCodeAt(i)) | 0
+    }
+    return (hash >>> 0) || 1 // ensure non-zero
+}
+
 function sumpart(idx: number):string  { return `sum(('x' || substring(t.rowhash, ${idx}, 8))::bit(32)::bigint) as sum${idx}` }
 function sums(): string               { return `${sumpart(1)}, ${sumpart(9)}, ${sumpart(17)}, ${sumpart(25)}` }
 function md5col(col: string): string  { return `md5(${col}::text)` }

--- a/packages/server/src/sync/dbwrapper.ts
+++ b/packages/server/src/sync/dbwrapper.ts
@@ -2,10 +2,11 @@ import { parseTimestamp } from 'sctypes/util'
 import { pgp, ScorekeeperProtocol, SYNCTABLES } from 'scdb'
 import { synclog } from '@/util/logging'
 import { getRemoteDB } from './connections'
-import { asyncwait, FOREIGN_KEY_CONSTRAINT, logtablefor, PRIMARY_TVEQ, PRIMARY_SETS } from './constants'
+import { asyncwait, FOREIGN_KEY_CONSTRAINT, logtablefor, PRIMARY_TVEQ, PRIMARY_SETS, seriesLockId, PUBLIC_TABLES } from './constants'
 import { MergeServerEntry } from './mergeserver'
 import { DBObject, DeletedObject, getPKHash, LoggedObject, PrimaryKeyHash, SyncError, TableName } from './types'
 
+const GLOBAL_LOCK_ID = 42
 
 /* eslint-disable lines-between-class-members */
 export async function performSyncWrap(roottask: ScorekeeperProtocol, localserver: MergeServerEntry, remoteserver: MergeServerEntry, series: string,
@@ -21,20 +22,29 @@ export async function performSyncWrap(roottask: ScorekeeperProtocol, localserver
     await getRemoteDB(remoteserver, series, password).task(async remotetask => {
         const wrap = new SyncProcessInfo(roottask, localserver, version, remotetask, remoteserver, series)
         try {
-            await wrap.getLocks()
+            await wrap.acquireSeriesLock()
             await execution(wrap)
         } finally {
-            await wrap.returnLocks()
+            await wrap.releaseAllLocks()
         }
     })
 }
 
 export class SyncProcessInfo {
-    lock1: ScorekeeperProtocol|undefined
-    lock2: ScorekeeperProtocol|undefined
+    private heldLocks: { conn1: ScorekeeperProtocol, conn2: ScorekeeperProtocol, lockId: number }[] = []
+    private conn1: ScorekeeperProtocol  // lower serverid locks first
+    private conn2: ScorekeeperProtocol
 
     constructor(private localtask: ScorekeeperProtocol,   private localserver: MergeServerEntry, private version: string,
                private remotetask: ScorekeeperProtocol,  private remoteserver: MergeServerEntry, private series: string) {
+        // Ordered locking: lower serverid first to prevent distributed deadlocks
+        if (this.localserver.serverid < this.remoteserver.serverid) {
+            this.conn1 = this.localtask
+            this.conn2 = this.remotetask
+        } else {
+            this.conn1 = this.remotetask
+            this.conn2 = this.localtask
+        }
     }
 
     async updateRemoteCache() {
@@ -64,6 +74,18 @@ export class SyncProcessInfo {
             throw Error('Unable to find tables hash status')
         }
         return [...new Set([...Object.keys(ltables), ...Object.keys(rtables)].filter(table => ltables[table] !== rtables[table]))]
+    }
+
+    needsPublicTables(tables: string[]): boolean {
+        return tables.some(t => PUBLIC_TABLES.includes(t))
+    }
+
+    publicTables(tables: string[]): string[] {
+        return tables.filter(t => PUBLIC_TABLES.includes(t))
+    }
+
+    seriesTables(tables: string[]): string[] {
+        return tables.filter(t => !PUBLIC_TABLES.includes(t))
     }
 
     async loadAll(table: string)  {
@@ -216,60 +238,79 @@ export class SyncProcessInfo {
         })
     }
 
-    async getLocks() {
-        /*
-            Context manager to acquire/release advisory locks on both servers.
-            It will throw assertion error if it can't get both.  The logic for
-            first lock to obtain is there to help dynamic merging systems in
-            obtaining locks in the same order to reduce distributed lock race
-            conditions.  The current order is lower serverid first.
-            Also sets the series schema path so its all nicely tied away here.
-        */
-        let tries = 10
-        let cur1  = this.localtask
-        let cur2  = this.remotetask
+    /**
+     * Acquire the per-series advisory lock on both servers.
+     * This is held for the duration of series-specific table syncing.
+     */
+    async acquireSeriesLock() {
+        const lockId = seriesLockId(this.series)
+        await Promise.all([this.conn1.series.setSeries(this.series), this.conn2.series.setSeries(this.series)])
+        await this.acquireLock(lockId, `series ${this.series}`)
+    }
 
-        if (this.localserver.serverid >= this.remoteserver.serverid) {
-            cur1 = this.remotetask
-            cur2 = this.localtask
+    /**
+     * Acquire the global advisory lock on both servers.
+     * This is held only while syncing public tables (drivers, weekendmembers).
+     */
+    async acquireGlobalLock() {
+        await this.acquireLock(GLOBAL_LOCK_ID, 'global (public tables)')
+    }
+
+    /**
+     * Release the global advisory lock on both servers.
+     */
+    async releaseGlobalLock() {
+        await this.releaseLock(GLOBAL_LOCK_ID, 'global (public tables)')
+    }
+
+    /**
+     * Release all held locks in reverse order (called in finally block).
+     */
+    async releaseAllLocks() {
+        await this.remotetask.none('ROLLBACK').catch(error => { synclog.error(error) })
+        await this.localtask.none('ROLLBACK').catch(error => { synclog.error(error) })
+
+        // Release in reverse order to avoid deadlock
+        for (let i = this.heldLocks.length - 1; i >= 0; i--) {
+            const held = this.heldLocks[i]
+            synclog.debug(`Releasing lock ${held.lockId}`)
+            await held.conn2.one('SELECT pg_advisory_unlock($1)', [held.lockId]).catch(error => synclog.error(error))
+            await held.conn1.one('SELECT pg_advisory_unlock($1)', [held.lockId]).catch(error => synclog.error(error))
         }
+        this.heldLocks = []
+    }
 
-        await Promise.all([cur1.series.setSeries(this.series), cur2.series.setSeries(this.series)])
-
+    private async acquireLock(lockId: number, label: string) {
+        let tries = 10
         while (tries > 0) {
-            const stat1 = await cur1.one('SELECT pg_try_advisory_lock(42) as lock')
+            const stat1 = await this.conn1.one('SELECT pg_try_advisory_lock($1) as lock', [lockId])
             if (stat1.lock) {
-                this.lock1 = cur1
-                const stat2 = await cur2.one('SELECT pg_try_advisory_lock(42) as lock')
+                const stat2 = await this.conn2.one('SELECT pg_try_advisory_lock($1) as lock', [lockId])
                 if (stat2.lock) {
-                    this.lock2 = cur2
-                    synclog.debug('Acquired both locks')
+                    this.heldLocks.push({ conn1: this.conn1, conn2: this.conn2, lockId })
+                    synclog.debug(`Acquired ${label} lock (lockId=${lockId})`)
                     return
                 }
+                // Got first but not second — release first and retry
+                await this.conn1.one('SELECT pg_advisory_unlock($1)', [lockId])
             }
 
-            // Failed on lock1 or lock2, release the lock we did get, wait and retry
-            synclog.warn('Unable to obtain locks, sleeping and trying again')
-            if (this.lock1) { await this.lock1.one('SELECT pg_advisory_unlock(42)') }
+            synclog.warn(`Unable to obtain ${label} lock, sleeping and trying again`)
             await asyncwait(1000)
             tries -= 1
         }
 
-        throw new SyncError('Unable to obtain locks, will try again later')
+        throw new SyncError(`Unable to obtain ${label} lock, will try again later`)
     }
 
-    async returnLocks() {
-        // needed coming from psycopg to make sure it was clear, FINISH ME, check here now
-        await this.remotetask.none('ROLLBACK').catch(error => { synclog.error(error) })
-        await this.localtask.none('ROLLBACK').catch(error => { synclog.error(error) })
+    private async releaseLock(lockId: number, label: string) {
+        const idx = this.heldLocks.findIndex(h => h.lockId === lockId)
+        if (idx === -1) return
 
-        synclog.debug('Releasing locks')
-        // Release locks in opposite order from obtaining to avoid deadlock
-        if (this.lock2) {
-            await this.lock2.one('SELECT pg_advisory_unlock(42)').catch(error => synclog.error(error))
-        }
-        if (this.lock1) {
-            await this.lock1.one('SELECT pg_advisory_unlock(42)').catch(error => synclog.error(error))
-        }
+        const held = this.heldLocks[idx]
+        synclog.debug(`Releasing ${label} lock (lockId=${lockId})`)
+        await held.conn2.one('SELECT pg_advisory_unlock($1)', [held.lockId]).catch(error => synclog.error(error))
+        await held.conn1.one('SELECT pg_advisory_unlock($1)', [held.lockId]).catch(error => synclog.error(error))
+        this.heldLocks.splice(idx, 1)
     }
 }

--- a/packages/server/src/sync/process.ts
+++ b/packages/server/src/sync/process.ts
@@ -136,20 +136,35 @@ async function mergeWith(roottask: ScorekeeperProtocol, myserver: MergeServerEnt
 
 
 async function mergeTables(wrap: SyncProcessInfo, tables: string[]) {
-    // Outer loop to rerun mergeTables and rerun, if for some reason we are still not up to date
-    let mtables = [...tables] // copy table
-    let ii
-    for (ii = 0; ii < 5; ii++) {
-        if (mtables.length <= 0) {
-            break
-        }
-        mtables = await mergeTablesInternal(wrap, mtables)
-        if (mtables.length) {
-            synclog.warn(`unfinished tables = ${mtables}`)
-        }
+    // Public tables (drivers, weekendmembers) are shared across all series and
+    // require a global advisory lock. Series-specific tables only need the
+    // per-series lock (already held). We acquire the global lock only when
+    // public tables need syncing, but run them together in one pass to
+    // preserve FK ordering (inserts top-down, deletes bottom-up).
+    const needsGlobal = wrap.needsPublicTables(tables)
+
+    if (needsGlobal) {
+        await wrap.acquireGlobalLock()
     }
-    if (ii === 5) {
-        synclog.error('Ran merge tables 5 times and not complete.')
+    try {
+        let mtables = [...tables]
+        let ii
+        for (ii = 0; ii < 5; ii++) {
+            if (mtables.length <= 0) {
+                break
+            }
+            mtables = await mergeTablesInternal(wrap, mtables)
+            if (mtables.length) {
+                synclog.warn(`unfinished tables = ${mtables}`)
+            }
+        }
+        if (ii === 5) {
+            synclog.error('Ran merge tables 5 times and not complete.')
+        }
+    } finally {
+        if (needsGlobal) {
+            await wrap.releaseGlobalLock()
+        }
     }
 
     // Rescan the tables to verify we are at the same state


### PR DESCRIPTION
…(fixes #100)

  Three files modified, one new test file:

  packages/server/src/sync/constants.ts — Added seriesLockId() function that generates a stable numeric lock ID from a series name using djb2 hash. Exported
  PUBLIC_TABLES array (drivers, weekendmembers) for use by the locking logic.

  packages/server/src/sync/dbwrapper.ts — Rewrote locking mechanism in SyncProcessInfo. Replaced the single global advisory lock with a two-tier system: a per-series
  lock (always held during series sync) and a global lock (only acquired when public tables need syncing). Added ordered locking by serverid to prevent distributed
  deadlocks. Lock tracking uses a heldLocks array with proper acquire/release helpers and reverse-order cleanup in releaseAllLocks().

  packages/server/src/sync/process.ts — mergeTables() now conditionally acquires the global lock only when public tables (drivers, weekendmembers) differ between
  servers. All tables are still merged in a single pass to preserve FK ordering (inserts top-down, deletes bottom-up). Removed the intermediate mergeTableSet() function.

  packages/server/src/sync/__tests__/concurrent.ts (new) — Tests for concurrent series syncing: verifies seriesLockId produces distinct IDs, two independent series sync
  without contention, driver changes in one series don't block run sync in another, and new driver+car+runs sync correctly across series boundaries.